### PR TITLE
added yarn.lock to gitignore (to be removed later)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ dist-sources
 
 .npmrc
 /dist/
+
+/yarn.lock


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

yarn lock is only used for build process for now. should be removed later. Added it to gitignore to ensure CI/CD is running.