### PR TITLE
Github actions modification, so canary release goes to github and doe…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')" # job will not run, if triggered via ship-it
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # fetch all tags for ship-it
 
       - name: download + setup auto
         uses: auto-it/setup-auto@v1
@@ -28,15 +28,23 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@infineon"
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Create Release 
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          npm config set '//npm.fontawesome.com/:_authToken' "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
+          npm config set '//npm.fontawesome.com/:_authToken' "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}" 
           npm install
           npm run bundle
           auto shipit
+      - name: Npm Publish # takes version number from package.json, canary releases will not be published to NPM
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,14 +29,10 @@ jobs:
         with:
           node-version: 16
           registry-url: "https://npm.pkg.github.com"
-          scope: "@infineon"
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
 
       - name: Create Release 
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npm config set '//npm.fontawesome.com/:_authToken' "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}" 
           npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,14 @@ jobs:
           npm install
           npm run bundle
           auto shipit
+      - name: Switch registry to npmjs.org
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+          scope: "@infineon"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - name: Npm Publish # takes version number from package.json, canary releases will not be published to NPM
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Npm Publish # takes version number from package.json, canary releases will not be published to NPM
         uses: JS-DevTools/npm-publish@v1
         with:
+          registry: "https://registry.npmjs.org"
           token: ${{ secrets.NPM_TOKEN }}
           
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "plugins": [
       "npm",
       "released"
-    ],
-    "onlyPublishWithReleaseLabel": true
+    ]
   }
 }


### PR DESCRIPTION
Creating Github package before publishing to NPM
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.0--canary.28.a2d14bc95e6da15db58b9c46b1276e30eaf94998.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/design-system-bootstrap@1.3.0--canary.28.a2d14bc95e6da15db58b9c46b1276e30eaf94998.0
  # or 
  yarn add @infineon/design-system-bootstrap@1.3.0--canary.28.a2d14bc95e6da15db58b9c46b1276e30eaf94998.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
