### PR TITLE
repository name url fixed in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "1.1.0",
   "private": false,
   "description": "Infineon design system bootstrap components",
-  "homepage": "https://github.com/Infineon/IFX-Design-System-Bootstrap#readme",
+  "homepage": "https://github.com/Infineon/Infineon-Design-System-Bootstrap#readme",
   "bugs": {
-    "url": "https://github.com/Infineon/IFX-Design-System-Bootstrap/issues"
+    "url": "https://github.com/Infineon/Infineon-Design-System-Bootstrap/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Infineon/IFX-Design-System-Bootstrap.git"
+    "url": "git+https://github.com/Infineon/Infineon-Design-System-Bootstrap.git"
   },
   "files": [
     "dist",


### PR DESCRIPTION
github deployment tests
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.1--canary.29.5af41c9b857f787bc1259fada60500384f5420de.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/design-system-bootstrap@1.2.1--canary.29.5af41c9b857f787bc1259fada60500384f5420de.0
  # or 
  yarn add @infineon/design-system-bootstrap@1.2.1--canary.29.5af41c9b857f787bc1259fada60500384f5420de.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
