### PR TITLE
removed closed from PR types that trigger a new canary release as it …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,7 @@ on:
     types:
       - opened
       - reopened
-      - synchronize
-      - closed
+      - synchronize # canary on new commit
   push:
     branches:
       - master


### PR DESCRIPTION
…already gets triggered on open + synchronize

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
in main.yml, closed was removed as a trigger type. A new canary release gets triggered when a new PR is opened, reopened or synchronized, so closed is not needed. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.3--canary.32.417a0b65d5cf50aaf8de12b1241c798a82eab4df.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/design-system-bootstrap@1.2.3--canary.32.417a0b65d5cf50aaf8de12b1241c798a82eab4df.0
  # or 
  yarn add @infineon/design-system-bootstrap@1.2.3--canary.32.417a0b65d5cf50aaf8de12b1241c798a82eab4df.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
