### PR TITLE
update pathname of hero-banner-scss

### DIFF
--- a/src/hero-banner/_hero-banner.scss
+++ b/src/hero-banner/_hero-banner.scss
@@ -21,7 +21,7 @@
 
     &:after {
       content: "";
-      background-image: url("../public/CS_Herobanner_Mainpage_mobile.svg");
+      background-image: url("../../public/CS_Herobanner_Mainpage_mobile.svg");
       background-repeat: no-repeat;
       background-position: right center;
       background-size: contain;
@@ -34,7 +34,7 @@
       height: 100%;
 
       @include media-breakpoint-up(lg) {
-        background-image: url("../public/CS_Herobanner_Mainpage.svg");
+        background-image: url("../../public/CS_Herobanner_Mainpage.svg");
       }
     }
   }
@@ -113,17 +113,17 @@
 
   &::before {
     @include media-breakpoint-up(xxl) {
-      background-image: url("../public/CS_Herobanner_Subpage2.svg");
+      background-image: url("../../public/CS_Herobanner_Subpage2.svg");
       background-position: left center;
     }
   }
 
   &::after {
-    background-image: url("../public/CS_Herobanner_Subpage_Mobile.svg");
+    background-image: url("../../public/CS_Herobanner_Subpage_Mobile.svg");
     background-position: right center;
     
     @include media-breakpoint-up(lg) {
-      background-image: url("../public/CS_Herobanner_Subpage1.svg");
+      background-image: url("../../public/CS_Herobanner_Subpage1.svg");
     }
   }
 


### PR DESCRIPTION
Changed the pathname of the background images inside hero-banner.scss to point to the correct folder.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.0--canary.34.01ada8e141a3eec4f62967681512e3f51dc7bf3a.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/design-system-bootstrap@2.0.0--canary.34.01ada8e141a3eec4f62967681512e3f51dc7bf3a.1
  # or 
  yarn add @infineon/design-system-bootstrap@2.0.0--canary.34.01ada8e141a3eec4f62967681512e3f51dc7bf3a.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
