### PR TITLE
33 readme instructions for local development are outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ Use it to build & run storybook and distribute the Bootstrap SCSS.
 ### Prerequisites
 
 - [Node](https://nodejs.org/en/) v14 or older.
-- [Npm](https://www.npmjs.com/) v6.14.13 or older.
+- [Yarn](https://classic.yarnpkg.com/en/) v1.22.10 or older, or [Npm](https://www.npmjs.com/) v6.14.13 or older.
 
 ### Installation on React, Vue or Angular
 
+#### With Yarn
+
+```yarn add @infineon/design-system-bootstrap```
 #### With NPM
 
 ```npm install --save @infineon/design-system-bootstrap```
@@ -85,7 +88,7 @@ For React: https://fontawesome.com/v6/docs/web/use-with/react/
 
 #### !Important! Using Infineon-Design-System-Bootstrap with React:
 
-After running ```npm install```, you'll additionally have to copy the folder "node_modules/@infineon/design-system-bootstrap/public" to "node_modules/@infineon/design-system-bootstrap/src" in order to successfully start your React application.
+After running ```yarn install``` or ```npm install```, you'll additionally have to copy the folder "node_modules/@infineon/design-system-bootstrap/public" to "node_modules/@infineon/design-system-bootstrap/src" in order to successfully start your React application.
 
 
 <!-- USAGE EXAMPLES -->
@@ -104,13 +107,23 @@ https://storybook-bootstrap.icp.infineon.com
 Install all the modules and dependencies listed on the ```package.json``` file with:
 
 ```bash
+yarn install
+```
+
+or
+```bash
 npm install
 ```
 
 ### Build Storybook
 
 To deploy Storybook, we first need to export it as a static web app.
-To do so, we can use the inbuild ```build-storybook``` command with ```npm``` 
+To do so, we can use the inbuild ```build-storybook``` command with ```npm``` or ```yarn```.
+
+yarn storybook-build
+```
+
+or
 
 ```bash
 npm run storybook-build
@@ -120,7 +133,11 @@ This will generate a static Storybook in the ```storybook-static``` directory.
 
 ### Start Storybook
 
-To start storybook, simply run the inbuild command ```storybook-start``` with ```npm``` 
+To start storybook, simply run the inbuild command ```storybook-start``` with ```npm``` or ```yarn```.
+
+```bash
+yarn storybook-start
+```
 
 ```bash
 npm run storybook-start

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use it to build & run storybook and distribute the Bootstrap SCSS.
 
 #### With NPM
 
-1. ```npm install --save @infineon/design-system-bootstrap```
+```npm install --save @infineon/design-system-bootstrap```
 
 #### Add to main.js
 
@@ -68,7 +68,7 @@ Use it to build & run storybook and distribute the Bootstrap SCSS.
 
 #### Installation Fontawesome
 
-1. Send an email to dds@infineon.com to get the fontawesome token key. Then execute these two commands:
+Send an email to dds@infineon.com to get the fontawesome token key. Then execute these two commands:
 ```bash
 
 npm config set "@fortawesome:registry" https://npm.fontawesome.com/

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ npm install
 To deploy Storybook, we first need to export it as a static web app.
 To do so, we can use the inbuild ```build-storybook``` command with ```npm``` or ```yarn```.
 
+```bash
 yarn storybook-build
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use it to build & run storybook and distribute the Bootstrap SCSS.
 ### Prerequisites
 
 - [Node](https://nodejs.org/en/) v14 or older.
-- [Yarn](https://classic.yarnpkg.com/en/) v1.22.10 or older, or [Npm](https://www.npmjs.com/) v6.14.13 or older.
+- [Npm](https://www.npmjs.com/) v6.14.13 or older.
 
 ### Installation on React, Vue or Angular
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ yarn build-storybook
 or
 
 ```bash
-npm build-storybook
+npm run storybook-build
 ```
 
 This will generate a static Storybook in the ```storybook-static``` directory.
@@ -139,7 +139,7 @@ yarn start-storybook
 or
 
 ```bash
-npm start-storybook
+npm run storybook-start
 ```
 
 ```start-storybook``` also executes ```watch-css``` and ```watch-storybook``` which automatically update storybook on code change.

--- a/README.md
+++ b/README.md
@@ -62,10 +62,6 @@ Use it to build & run storybook and distribute the Bootstrap SCSS.
 
 1. ```npm install --save @infineon/design-system-bootstrap```
 
-#### With Yarn
-
-1. ```yarn add @infineon/design-system-bootstrap```
-
 #### Add to main.js
 
 ```import "@infineon/design-system-bootstrap";```
@@ -87,6 +83,11 @@ For React: https://fontawesome.com/v6/docs/web/use-with/react/
 
 <p align="right"><a href="#tableContent">back to top</a></p>
 
+#### !Important! Using Infineon-Design-System-Bootstrap with React:
+
+After running ```npm install```, you'll additionally have to copy the folder "node_modules/@infineon/design-system-bootstrap/public" to "node_modules/@infineon/design-system-bootstrap/src" in order to successfully start your React application.
+
+
 <!-- USAGE EXAMPLES -->
 ## Usage
 
@@ -103,24 +104,13 @@ https://storybook-bootstrap.icp.infineon.com
 Install all the modules and dependencies listed on the ```package.json``` file with:
 
 ```bash
-yarn install
-```
-
-or
-```bash
 npm install
 ```
 
 ### Build Storybook
 
 To deploy Storybook, we first need to export it as a static web app.
-To do so, we can use the inbuild ```build-storybook``` command with ```npm``` or ```yarn```.
-
-```bash
-yarn build-storybook
-```
-
-or
+To do so, we can use the inbuild ```build-storybook``` command with ```npm``` 
 
 ```bash
 npm run storybook-build
@@ -130,13 +120,7 @@ This will generate a static Storybook in the ```storybook-static``` directory.
 
 ### Start Storybook
 
-To start storybook, simply run the inbuild command ```storybook-start``` with ```npm``` or ```yarn```.
-
-```bash
-yarn start-storybook
-```
-
-or
+To start storybook, simply run the inbuild command ```storybook-start``` with ```npm``` 
 
 ```bash
 npm run storybook-start

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This will generate a static Storybook in the ```storybook-static``` directory.
 
 ### Start Storybook
 
-To start storybook, simply run the inbuild command ```start-storybook``` with ```npm``` or ```yarn```.
+To start storybook, simply run the inbuild command ```storybook-start``` with ```npm``` or ```yarn```.
 
 ```bash
 yarn start-storybook


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Readme updated to exclude yarn for local development and to include special considerations necessary when using the library with React.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.0--canary.35.b5b466edd645d0695d4390930193ffd5743e2fb4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/design-system-bootstrap@1.3.0--canary.35.b5b466edd645d0695d4390930193ffd5743e2fb4.0
  # or 
  yarn add @infineon/design-system-bootstrap@1.3.0--canary.35.b5b466edd645d0695d4390930193ffd5743e2fb4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
