### PR TITLE
update buttons color naming for storybook controls

### DIFF
--- a/src/button-group/ButtonGroup.jsx
+++ b/src/button-group/ButtonGroup.jsx
@@ -8,8 +8,8 @@ const propTypes = {
 
   /** Set button color */
   color: PropTypes.oneOf([
-    "primary",
-    "secondary",
+    "default",
+    "highlight",
     "success",
     "danger",
     "warning",

--- a/src/button-group/ButtonGroup.stories.jsx
+++ b/src/button-group/ButtonGroup.stories.jsx
@@ -5,7 +5,7 @@ export default {
   component: ButtonGroup,
   args: {
     variant: "solid",
-    color: "primary",
+    color: "default",
     size: "m",
     disabled: true,
   }

--- a/src/button/Button.jsx
+++ b/src/button/Button.jsx
@@ -11,8 +11,8 @@ const propTypes = {
 
   /** Set button color */
   color: PropTypes.oneOf([
-    "primary",
-    "secondary",
+    "default",
+    "highlight",
     "success",
     "danger",
     "warning",
@@ -38,9 +38,15 @@ const propTypes = {
 };
 
 export const Button = ({ label, variant, color, size, disabled, icon, iconPosition, children, ...props }) => {
+
+  const bsColor = 
+  color === 'default' ? 'primary' 
+  : color === 'highlight' ? 'secondary' 
+  : color 
+
   const bsVariant =
-    variant === "outline" ? `outline-${color}`
-    : color;
+    variant === "outline" ? `outline-${bsColor}`
+    : bsColor;
 
   const bsSize =
     size === "s" ? "sm" 

--- a/src/button/Button.stories.jsx
+++ b/src/button/Button.stories.jsx
@@ -8,7 +8,7 @@ export default {
   args: {
     label: "Button",
     variant: "solid",
-    color: "primary",
+    color: "default",
     size: "m",
     active: false,
     disabled: false,
@@ -40,10 +40,10 @@ export const Default = DefaultTemplate.bind({});
 export const ButtonBadge = ButtonBadgeTemplate.bind({});
 ButtonBadge.args = {
   label: "Notifications",
-  color: "secondary",
+  color: "highlight",
 };
 
 export const BorderSpinner = BorderSpinnerTemplate.bind({});
 BorderSpinner.args = {
-  color: "secondary",
+  color: "highlight",
 };


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

I have updated the button's color naming for storybook controls. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.5--canary.39.f87a3d506a13dd5971311f57ccf3d2c805d124ec.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/design-system-bootstrap@1.2.5--canary.39.f87a3d506a13dd5971311f57ccf3d2c805d124ec.0
  # or 
  yarn add @infineon/design-system-bootstrap@1.2.5--canary.39.f87a3d506a13dd5971311f57ccf3d2c805d124ec.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
